### PR TITLE
 Configure In-Memory SQLite Database for Testing

### DIFF
--- a/test/PublicTimelineTests.cs
+++ b/test/PublicTimelineTests.cs
@@ -7,15 +7,13 @@ using System.IO;
 
 namespace Chirp.Razor.test;
 
-public class PublicTimelineTests : IClassFixture<WebApplicationFactory<Program>>
+public class PublicTimelineTests : IClassFixture<TestingWebApplicationFactory>
 {
     private readonly HttpClient _client;
 
-    public PublicTimelineTests(WebApplicationFactory<Program> factory)
+    public PublicTimelineTests(TestingWebApplicationFactory factory)
     {
-        var dbPath = Path.Combine("db", "chirp.db");
-        Environment.SetEnvironmentVariable("CHIRPDBPATH", dbPath);
-
+        
         _client = factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = true

--- a/test/TestingWebApplicationFactory.cs
+++ b/test/TestingWebApplicationFactory.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using Chirp.Infrastructure.DataModel;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Chirp.Razor.test; 
+
+public class TestingWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private SqliteConnection? _connection;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+           
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ChatDBContext>));
+
+            if (descriptor is not null)
+                services.Remove(descriptor);
+
+         
+            _connection = new SqliteConnection("DataSource=:memory:");
+            _connection.Open();
+
+            services.AddDbContext<ChatDBContext>(options =>
+            {
+                options.UseSqlite(_connection);
+            });
+
+        
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ChatDBContext>();
+
+            db.Database.EnsureDeleted();
+            db.Database.Migrate();
+        });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            _connection?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Co-authored ChatGPT for testing: Set up integration tests to use an in-memory SQLite database to decouple the test suite from the production database. This allows for faster, isolated, and repeatable testing.

Criteria:
• Configure test project to use UseSqlite("DataSource=:memory:"). • Ensure migrations are applied on test startup.
• Verify tests run successfully without connecting to any external DB.